### PR TITLE
added Raspberry Pi override for /dev/gpiomem device (fix #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To allow data persistance, Docker volumes are required which will avoid to re-pa
 | `arm/v7`     | Such as Raspberry Pi 2/3/4                         |
 | `arm64`      | Such as Raspberry Pi 4 64-bit                      |
 
-The Raspberry Pi 3 is dectected automatically to allow GPIOmem device to be passed to the Skills container.
+The Raspberry Pi(s) are dectected automatically to allow GPIOmem device to be passed to the Skills container.
 *These are examples, many other boards use these CPU architectures.*
 
 | Tag | Description                                                                         |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ To allow data persistance, Docker volumes are required which will avoid to re-pa
 | `arm/v7`     | Such as Raspberry Pi 2/3/4                         |
 | `arm64`      | Such as Raspberry Pi 4 64-bit                      |
 
+The Raspberry Pi 3 is dectected automatically to allow GPIOmem device to be passed to the Skills container.
 *These are examples, many other boards use these CPU architectures.*
 
 | Tag | Description                                                                         |

--- a/docker-compose.raspberrypi.yml
+++ b/docker-compose.raspberrypi.yml
@@ -1,0 +1,5 @@
+---
+services:
+  mycroft_skills:
+    devices:
+      - /dev/gpiomem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,6 @@ services:
     network_mode: host
     devices:
       - /dev/snd
-      - /dev/gpiomem
     environment:
       PULSE_SERVER: unix:${XDG_RUNTIME_DIR}/pulse/native
       PULSE_COOKIE: /home/mycroft/.config/pulse/cookie

--- a/run.sh
+++ b/run.sh
@@ -75,8 +75,7 @@ done
 # This is done since amd64 computers do not have the same hardware device
 #  for GPIO pins like the Pi does.
 case $(uname -m) in
-    armv7l)
-    aarch64)
+    armv7l | aarch64)
         raspberrypi="true" ;;
 esac
 

--- a/run.sh
+++ b/run.sh
@@ -67,6 +67,13 @@ for COMMAND in "docker" "docker-compose"; do
     command_exists "${COMMAND}"
 done
 
+# Check if platform is Raspberry Pi, to apply it's own configuration later
+# This is done since amd64 computers do not have the same hardware device
+#  for GPIO pins like the Pi does.
+if [[ $(uname -m) == 'armv7l' ]]; then
+    raspberrypi="true"
+fi
+
 # Create Docker mount directories.
 #   - mycroft-config: Mycroft configuration file such as mycroft.conf
 #   - mycroft-web-cache: Configuration sent by Selene backend to the device
@@ -93,5 +100,9 @@ else
 fi
 
 # Execute docker-compose using the docker-compose.yml file from the
-# same directory.
-docker-compose up -d
+# same directory, adding the Raspberry Pi override if necessary.
+if [ -z $raspberrypi ]; then
+    docker-compose -f docker-compose.yml up -d
+else
+    docker-compose -f docker-compose.yml -f docker-compose.raspberrypi.yml up -d
+fi

--- a/run.sh
+++ b/run.sh
@@ -70,9 +70,11 @@ done
 # Check if platform is Raspberry Pi, to apply it's own configuration later
 # This is done since amd64 computers do not have the same hardware device
 #  for GPIO pins like the Pi does.
-if [[ $(uname -m) == 'armv7l' ]]; then
-    raspberrypi="true"
-fi
+case $(uname -m) in
+    armv7l)
+    aarch64)
+        raspberrypi="true" ;;
+esac
 
 # Create Docker mount directories.
 #   - mycroft-config: Mycroft configuration file such as mycroft.conf


### PR DESCRIPTION
Like title says.

Currently tested working on Kubuntu 20.04 representing `x86_64` (`amd64`) and a Raspberry Pi 3b+.
I could need someone with a Raspberry Pi 4 to provide me the result of `uname -m` from console.